### PR TITLE
use correct name. text --> buf

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,6 @@ module.exports.tidyBuffer = function(buf, opts, cb) {
   var doc = TidyDoc();
   doc.options = opts;
   if (!Buffer.isBuffer(buf))
-    text = Buffer(String(buf));
+    buf = Buffer(String(buf));
   doc.tidyBuffer(buf, cb);
 };


### PR DESCRIPTION
It looks as if code from https://github.com/gagern/node-libtidy/blob/db92f2b5aa9211fc00b1007970f6cc2ed1b72a63/src/htmltidy.js
was copied over but not changed correctly everywhere.
