### PR TITLE
adding npm-debug.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /node_modules/
 .gdb_history
+npm-debug.log


### PR DESCRIPTION
on failed npm install this file is created. e.g. when submodule has not been initialized
