### PR TITLE
Prevent segfault when attempting to set readonly property

### DIFF
--- a/src/doc.cc
+++ b/src/doc.cc
@@ -214,6 +214,12 @@ namespace node_libtidy {
     Doc* doc = Prelude(info.Holder()); if (!doc) return;
     TidyOption opt = doc->asOption(info[0]);
     if (!opt) return;
+    if (tidyOptIsReadOnly(opt) != no) {
+      std::ostringstream buf;
+      buf << "Option '" << tidyOptGetName(opt) << "' is readonly";
+      Nan::ThrowError(NewString(buf.str()));
+      return;
+    }
     TidyOptionId id = tidyOptGetId(opt);
     v8::Local<v8::Value> val = info[1];
     Bool rc;

--- a/test/opt-test.js
+++ b/test/opt-test.js
@@ -84,11 +84,14 @@ describe("TidyOption:", function() {
       }).to.throw();
     });
 
-    it("setting a readonly option throw", function() {
+    it("setting a readonly option throws", function() {
       var doc = TidyDoc();
-      var opt = doc.getOption(8);
+      var opt = doc.getOption('doctype-mode');
+      // If readOnly changes in future, this will help to locate the fail.
       expect(opt.readOnly).to.be.true;
-      expect(function() { doc.optSet(8); }).to.throw(Error, /' is readonly/);
+      expect(function() {
+        doc.optSet('doctype-mode');
+      }).to.throw(Error, /' is readonly/);
     });
 
     it("can handle integer options", function() {

--- a/test/opt-test.js
+++ b/test/opt-test.js
@@ -84,6 +84,13 @@ describe("TidyOption:", function() {
       }).to.throw();
     });
 
+    it("setting a readonly option throw", function() {
+      var doc = TidyDoc();
+      var opt = doc.getOption(8);
+      expect(opt.readOnly).to.be.true;
+      expect(function() { doc.optSet(8); }).to.throw(Error, /' is readonly/);
+    });
+
     it("can handle integer options", function() {
       var doc = TidyDoc();
       expect(doc.optGet("tab-size")).to.be.equal(8);

--- a/test/opt-test.js
+++ b/test/opt-test.js
@@ -81,7 +81,7 @@ describe("TidyOption:", function() {
       expect(doc.optGet("add-xml-decl")).to.be.false;
       expect(function() {
         doc.optSet("add-xml-decl", "some strange value");
-      }).to.throw;
+      }).to.throw();
     });
 
     it("can handle integer options", function() {
@@ -93,7 +93,7 @@ describe("TidyOption:", function() {
       expect(doc.optGet("tab-size")).to.be.equal(5);
       expect(doc.optSet("tab-size", 2.2)).to.be.undefined;
       expect(doc.optGet("tab-size")).to.be.equal(2);
-      expect(function() { doc.optSet("tab-size", "not a number"); }).to.throw;
+      expect(function() { doc.optSet("tab-size", "not a number"); }).to.throw();
     });
 
     it("can handle the char-encoding option", function() {
@@ -103,7 +103,7 @@ describe("TidyOption:", function() {
       expect(doc.optGet("char-encoding")).to.be.equal(utf8);
       expect(doc.optSet("char-encoding", "latin1")).to.be.undefined;
       expect(doc.optGet("char-encoding")).to.be.not.equal(utf8);
-      expect(function() { doc.optSet("char-encoding", "foobar"); }).to.throw;
+      expect(function() { doc.optSet("char-encoding", "foobar"); }).to.throw();
     });
 
     it("can handle the newline option", function() {
@@ -114,7 +114,7 @@ describe("TidyOption:", function() {
       expect(doc.optGet("newline")).to.be.equal("CRLF");
       expect(doc.optSet("newline", 2)).to.be.undefined;
       expect(doc.optGet("newline")).to.be.equal("CR");
-      expect(function() { doc.optSet("newline", "yes"); }).to.throw;
+      expect(function() { doc.optSet("newline", "yes"); }).to.throw();
     });
 
     it("can handle AutoBool options", function() {
@@ -128,7 +128,7 @@ describe("TidyOption:", function() {
       expect(doc.optGet("indent")).to.be.equal("no");
       expect(doc.optSet("indent", true)).to.be.undefined;
       expect(doc.optGet("indent")).to.be.equal("yes");
-      expect(function() { doc.optSet("indent", "unknown"); }).to.throw;
+      expect(function() { doc.optSet("indent", "unknown"); }).to.throw();
     });
 
     it("can find current value from enum", function() {


### PR DESCRIPTION
The following code caused segfault in osx / linux. I suppose a JS exception would be more friendly.

```js
var libtidy = require('libtidy');
var c = new libtidy.TidyDoc();
c.optSet(8); // 8 for the only readonly option "doctype-mode"
```

Also changed a few tests to call `to.throw()`: the `throw` assertion does not work without `()`).